### PR TITLE
[Discussion] Proposal to future v4 build

### DIFF
--- a/Dockerfile-v4
+++ b/Dockerfile-v4
@@ -1,9 +1,17 @@
+FROM cachyos/cachyos:latest as qemu-x86_64-static
+
+RUN pacman -Sy && \
+    pacman -S --needed --noconfirm qemu-user-static
+
 FROM cachyos/cachyos:latest as rootfs
 
+COPY --from=qemu-x86_64-static --chmod=755 /usr/bin/qemu-x86_64-static /tmp/qemu-x86_64-static 
+
 COPY pacman-v4.conf /etc/pacman.conf
-RUN pacman -Syu --noconfirm && \
-    rm -rf /var/lib/pacman/sync/* && \
-    find /var/cache/pacman/ -type f -delete
+RUN /tmp/qemu-x86_64-static --cpu Skylake-Server-v5 pacman -Syu --noconfirm && \
+    /tmp/qemu-x86_64-static --cpu Skylake-Server-v5 rm -rf /var/lib/pacman/sync/* && \
+    /tmp/qemu-x86_64-static --cpu Skylake-Server-v5 find /var/cache/pacman/ -type f -delete && \
+    /tmp/qemu-x86_64-static --cpu Skylake-Server-v5 find /tmp/qemu-x86_64-static -type f -delete 
 
 FROM scratch
 LABEL org.opencontainers.image.description="CachyOS - Arch-based distribution offering an easy installation, several customizations, and unique performance optimization. - v4 optimized Packages"


### PR DESCRIPTION
Hello!

This PR brings an idea to future: When qemu-static binaries supports v4 stacks, this Dockerfile-v4 maybe able to build x86_64_v4 version at any CPU (Including Github hosts itself).

QEMU does [already support v3](https://gitlab.com/qemu-project/qemu/-/issues/844) but v4/avx512 support wasn't considered important at time to be supported on Qemu TCG. Maybe report an issue on qemu issues helps to this support comes in, but without _qemu-x86_64-static_, CachyOS v4 builds will be only able to be built on proper v4 hardware.

That said, what are CachyOS mantainers thoughts about my suggestion at Dockerfile-v4?